### PR TITLE
CanInterface() called before Interface()  (#463)

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -96,7 +96,7 @@ func (e *encoder) marshalDoc(tag string, in reflect.Value) {
 }
 
 func (e *encoder) marshal(tag string, in reflect.Value) {
-	if !in.IsValid() || in.Kind() == reflect.Ptr && in.IsNil() {
+	if !in.CanInterface() || !in.IsValid() || in.Kind() == reflect.Ptr && in.IsNil() {
 		e.nilv()
 		return
 	}


### PR DESCRIPTION
Test on the CanInterface() returned value before calling Interface() while marshaling (#463)